### PR TITLE
Bump Java SDK from 2.23.1 to 2.26.1 nd OTel Collector from 0.147.0 to…

### DIFF
--- a/kubernetes/otel-kube-stack-helm-chart/examples/collector_presets_infra-monitoring_disabled/rendered/instrumentation.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/collector_presets_infra-monitoring_disabled/rendered/instrumentation.yaml
@@ -28,7 +28,7 @@ spec:
     env:
     - name: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_KEY_VALUE_PAIR_ATTRIBUTES
       value: "true"
-    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.23.1
+    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.26.1
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.71.0
   python:

--- a/kubernetes/otel-kube-stack-helm-chart/examples/collector_presets_infra-monitoring_disabled/rendered/opentelemetry-operator/deployment.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/collector_presets_infra-monitoring_disabled/rendered/opentelemetry-operator/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.147.0
+            - --collector-image=otel/opentelemetry-collector-contrib:0.148.0
           command:
             - /manager
           env:

--- a/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/instrumentation.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/instrumentation.yaml
@@ -28,7 +28,7 @@ spec:
     env:
     - name: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_KEY_VALUE_PAIR_ATTRIBUTES
       value: "true"
-    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.23.1
+    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.26.1
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.71.0
   python:

--- a/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/opentelemetry-operator/deployment.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/opentelemetry-operator/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.147.0
+            - --collector-image=otel/opentelemetry-collector-contrib:0.148.0
           command:
             - /manager
           env:

--- a/kubernetes/otel-kube-stack-helm-chart/examples/operator_cert-manager_enabled/rendered/instrumentation.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/operator_cert-manager_enabled/rendered/instrumentation.yaml
@@ -28,7 +28,7 @@ spec:
     env:
     - name: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_KEY_VALUE_PAIR_ATTRIBUTES
       value: "true"
-    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.23.1
+    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.26.1
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.71.0
   python:

--- a/kubernetes/otel-kube-stack-helm-chart/examples/operator_cert-manager_enabled/rendered/opentelemetry-operator/deployment.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/operator_cert-manager_enabled/rendered/opentelemetry-operator/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=otel/opentelemetry-collector-contrib:0.147.0
+            - --collector-image=otel/opentelemetry-collector-contrib:0.148.0
           command:
             - /manager
           env:

--- a/kubernetes/otel-kube-stack-helm-chart/values.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/values.yaml
@@ -133,7 +133,7 @@ instrumentation:
     type: parentbased_always_on
   java:
     # renovate: datasource=docker depName=grafana-opentelemetry-java packageName=us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java
-    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.23.1
+    image: us-docker.pkg.dev/grafanalabs-global/docker-grafana-opentelemetry-java-prod/grafana-opentelemetry-java:2.26.1
     env:
     - name: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_KEY_VALUE_PAIR_ATTRIBUTES
       value: "true"
@@ -150,7 +150,7 @@ opentelemetry-operator:
   manager:
     collectorImage:
       repository: otel/opentelemetry-collector-contrib
-      tag: "0.147.0"
+      tag: "0.148.0"
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8080"


### PR DESCRIPTION
## Dependency updates

### OpenTelemetry Java Auto-Instrumentation (`grafana-opentelemetry-java`)
**Bumped:** `2.23.1` → `2.26.1`

Key upstream changes across `2.24.0` / `2.25.0` / `2.26.0` / `2.26.1`:

- **OTel SDK baseline upgrade:** `2.23.x` targets OpenTelemetry SDK **1.57.0**, while `2.26.0` targets OpenTelemetry SDK **1.60.1**.
- **Security fix in 2.26.1:** fixes an unsafe deserialization issue in **RMI instrumentation** that could lead to **RCE** (**CVE-2026-33701**).
- **Non-stable API breaking changes (2.26.0):** includes breaking changes to non-stable APIs (e.g., removal of deprecated AWS Lambda wrappers / overloads).

### OpenTelemetry Collector Contrib (`otel/opentelemetry-collector-contrib`)
**Bumped:** `0.147.0` → `0.148.0`

Notable upstream changes in `0.148.0`:

- **Breaking removals**
  - Removes the **`k8slog` receiver** (unmaintained).
  - Removes deprecated **SAPM exporter**.
  - Removes **datadogsemantics processor**.
- **Kafka exporter breaking change:** removes deprecated top-level `topic` / `encoding` fields (must use per-signal fields instead).
- **OTTL behavior change:** `truncate_all` becomes **UTF-8-safe by default** (set `utf8_safe: false` to revert previous behavior).
- **Receiver default changes**
  - **mysql receiver:** `query_sample` default collection disabled.
  - **postgresql receiver:** default collection of `top_query` and `query_sample` events disabled.

> References: OpenTelemetry Java Instrumentation and OpenTelemetry Collector Contrib release notes.