### PR TITLE
[App O11y] Remove references to `grafanacloud` connector

### DIFF
--- a/kubernetes/otel-kube-stack-helm-chart/examples/collector_presets_infra-monitoring_disabled/rendered/collector.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/collector_presets_infra-monitoring_disabled/rendered/collector.yaml
@@ -14,12 +14,6 @@ spec:
   managementState: managed
   mode: daemonset
   config:
-    connectors:
-      grafanacloud/connector:
-        host_identifiers:
-        - host.id
-        - k8s.node.uid
-        - k8s.node.name
     exporters:
       debug: {}
       otlphttp/grafana_cloud:
@@ -163,12 +157,10 @@ spec:
           - batch
           receivers:
           - otlp
-          - grafanacloud/connector
           - receiver_creator/metrics
         traces:
           exporters:
           - otlphttp/grafana_cloud
-          - grafanacloud/connector
           processors:
           - k8sattributes
           - resourcedetection/env

--- a/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/collector.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/collector.yaml
@@ -14,12 +14,6 @@ spec:
   managementState: managed
   mode: daemonset
   config:
-    connectors:
-      grafanacloud/connector:
-        host_identifiers:
-        - host.id
-        - k8s.node.uid
-        - k8s.node.name
     exporters:
       debug: {}
       otlphttp/grafana_cloud:
@@ -163,12 +157,10 @@ spec:
           - batch
           receivers:
           - otlp
-          - grafanacloud/connector
           - receiver_creator/metrics
         traces:
           exporters:
           - otlphttp/grafana_cloud
-          - grafanacloud/connector
           processors:
           - k8sattributes
           - resourcedetection/env

--- a/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -1,5 +1,11 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -193,12 +199,6 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
----
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
----
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 apiVersion: v1

--- a/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/default/rendered/opentelemetry-operator/admission-webhooks/operator-webhook.yaml
@@ -1,11 +1,5 @@
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
----
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
----
----
-# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -199,6 +193,12 @@ webhooks:
         scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
+---
+# Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
+---
 ---
 # Source: opentelemetry-kube-stack/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook.yaml
 apiVersion: v1

--- a/kubernetes/otel-kube-stack-helm-chart/examples/operator_cert-manager_enabled/rendered/collector.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/examples/operator_cert-manager_enabled/rendered/collector.yaml
@@ -14,12 +14,6 @@ spec:
   managementState: managed
   mode: daemonset
   config:
-    connectors:
-      grafanacloud/connector:
-        host_identifiers:
-        - host.id
-        - k8s.node.uid
-        - k8s.node.name
     exporters:
       debug: {}
       otlphttp/grafana_cloud:
@@ -163,12 +157,10 @@ spec:
           - batch
           receivers:
           - otlp
-          - grafanacloud/connector
           - receiver_creator/metrics
         traces:
           exporters:
           - otlphttp/grafana_cloud
-          - grafanacloud/connector
           processors:
           - k8sattributes
           - resourcedetection/env

--- a/kubernetes/otel-kube-stack-helm-chart/values.yaml
+++ b/kubernetes/otel-kube-stack-helm-chart/values.yaml
@@ -51,9 +51,6 @@ collectors:
         metrics:
           enabled: true
     config:
-      connectors:
-        grafanacloud/connector:
-          host_identifiers: ["host.id", "k8s.node.uid", "k8s.node.name"]
       extensions:
         basicauth/grafana_cloud:
           client_auth:
@@ -70,11 +67,9 @@ collectors:
           traces:
             exporters:
               - otlphttp/grafana_cloud
-              - grafanacloud/connector
           metrics:
             receivers:
               - otlp
-              - grafanacloud/connector
             exporters:
               - otlphttp/grafana_cloud
           logs:

--- a/linux/collector.yaml
+++ b/linux/collector.yaml
@@ -101,6 +101,12 @@ processors:
     spike_limit_percentage: 25
   resourcedetection:
     detectors: [env, system]
+    system:
+      resource_attributes:
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
   transform/promote_metric_attributes:
     metric_statements:
       - set(datapoint.attributes["host.name"],resource.attributes["host.name"])
@@ -111,10 +117,6 @@ processors:
       - set(resource.attributes["service.name"],log.attributes["_SYSTEMD_UNIT"])
       - delete_key(log.attributes,"MESSAGE")
 
-connectors:
-  grafanacloud/connector:
-    host_identifiers: ["host.id", "k8s.node.uid", "k8s.node.name", "host.name"]
-
 service:
   extensions: [basicauth/grafana_cloud]
   pipelines:
@@ -123,11 +125,9 @@ service:
       processors: ["memory_limiter", "resourcedetection"]
       exporters:
         - otlphttp/grafana_cloud
-        - grafanacloud/connector
     metrics:
       receivers:
         - otlp
-        - grafanacloud/connector
         - hostmetrics
       processors:
         [


### PR DESCRIPTION
  - `grafanacloudconnector` has been deprecated and is no longer required
  - instead, auto-metering takes care of extracting host-hours for users
  - See https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/pricing/